### PR TITLE
Fix linting: remove conflicting access modifier in private extension

### DIFF
--- a/FreeThinker/Core/Services/DefaultTextCaptureService.swift
+++ b/FreeThinker/Core/Services/DefaultTextCaptureService.swift
@@ -89,6 +89,24 @@ public actor DefaultTextCaptureService: TextCaptureServiceProtocol {
         Logger.info("Selection capture yielded no text", category: .textCapture)
         throw FreeThinkerError.noSelection
     }
+
+    public func requestAccessibilityPermissionPromptIfNeeded() {
+        let now = uptimeNanosecondsProvider()
+        if
+            let lastPromptUptime = lastPermissionPromptUptimeNanoseconds,
+            now >= lastPromptUptime,
+            (now - lastPromptUptime) < permissionPromptCooldownNanoseconds
+        {
+            return
+        }
+
+        lastPermissionPromptUptimeNanoseconds = now
+        let alreadyTrusted = permissionPromptRequester()
+        Logger.info(
+            "Requested accessibility permission prompt trusted=\(alreadyTrusted)",
+            category: .textCapture
+        )
+    }
 }
 
 private extension DefaultTextCaptureService {
@@ -167,24 +185,6 @@ private extension DefaultTextCaptureService {
     static func requestAccessibilityPermissionPrompt() -> Bool {
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
         return AXIsProcessTrustedWithOptions(options)
-    }
-
-    public func requestAccessibilityPermissionPromptIfNeeded() {
-        let now = uptimeNanosecondsProvider()
-        if
-            let lastPromptUptime = lastPermissionPromptUptimeNanoseconds,
-            now >= lastPromptUptime,
-            (now - lastPromptUptime) < permissionPromptCooldownNanoseconds
-        {
-            return
-        }
-
-        lastPermissionPromptUptimeNanoseconds = now
-        let alreadyTrusted = permissionPromptRequester()
-        Logger.info(
-            "Requested accessibility permission prompt trusted=\(alreadyTrusted)",
-            category: .textCapture
-        )
     }
 
     func fallbackCaptureSelection() async -> String? {


### PR DESCRIPTION
## Summary
- Moves `requestAccessibilityPermissionPromptIfNeeded()` from `private extension DefaultTextCaptureService` into the main actor body
- Eliminates the Swift compiler warning about a `public` modifier conflicting with the enclosing `private` extension's default access level
- The method satisfies a `public` protocol requirement in `TextCaptureServiceProtocol`, so it must be `public` and live outside the private extension

## Test plan
- [ ] `swift build` produces zero warnings and zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)